### PR TITLE
Added `h-full` class to `.parent` div in Mission component.

### DIFF
--- a/src/components/mission/index.jsx
+++ b/src/components/mission/index.jsx
@@ -22,7 +22,7 @@ export default function Mission(){
     const missions = csi.map(mission => {
         return(
             <div className="relative group">
-            <div className="parent flex flex-col border-2 border-gray-400 p-4 text-white relative z-10 shadow-md shadow-gray-500">
+            <div className="parent flex flex-col border-2 border-gray-400 p-4 text-white relative z-10 shadow-md shadow-gray-500 h-full">
                 <img src={`/images/mission/${mission.image}`} alt="" className="w-32 h-32 md:w-40 md:h-40 self-center" />
                 <span className="text-center font-bold text-lg md:text-lg lg:text-2xl uppercase">{mission.title}</span>
                 <span className="text-center mt-2 md:mt-3 text-xs sm:text-sm lg:text-base xl:text-xl ">{mission.content}</span>


### PR DESCRIPTION
## Title:
<!--Provide a clear title for your PR in order to have a precise summary-->
Fix: Inconsistent Card Heights on Home Page

## Issue no:
<!--Mention the issue number using the '#' symbol followed by the issue number OR you may provide the link-->
#3 

## Description:
<!--Provide the brief description of the changes you've made-->
This PR resolves the issue of inconsistent card heights on the home page. Specifically, I added the `h-full` class to the `.parent` div in the **Mission** component, ensuring all cards maintain a consistent height.

## Screenshots (if applicable):
<!--![Screenshot](url-to-screenshot)-->
*Before:*  
<img width="1427" alt="Screenshot 2024-10-16 at 11 40 02 PM" src="https://github.com/user-attachments/assets/beeaa61a-3af6-4336-98d6-df9144308dd1">


*After:*  
<img width="1427" alt="Screenshot 2024-10-16 at 11 50 28 PM" src="https://github.com/user-attachments/assets/362c59f6-fde0-4ba1-b3cd-ee6ab2b6a436">

## Checklist:
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/tcet-opensource/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have read and followed the **Contributing Guidelines**
